### PR TITLE
Enable CheckAppVersion middleware in app bootstrap

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,8 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
         apiPrefix: 'api',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
-        // $middleware->append(CheckAppVersion::class);
+        $middleware->append(CheckAppVersion::class);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->report(function (\Throwable $e) {


### PR DESCRIPTION
This pull request includes a minor update to the `bootstrap/app.php` file. The change re-enables the `CheckAppVersion` middleware by appending it back to the middleware stack.