### PR TITLE
Update CORS configuration to set max_age to 86400 seconds and disable supports_credentials

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -14,10 +14,8 @@ return [
 
     'exposed_headers' => [],
 
-    'max_age' => 0,
+    'max_age' => 86400,
 
-    // 'supports_credentials' => false,
-
-    'supports_credentials' => true,
+    'supports_credentials' => false,
 
 ];


### PR DESCRIPTION
This pull request includes updates to the CORS configuration file to adjust settings for better compatibility and security.

CORS configuration updates:

* [`config/cors.php`](diffhunk://#diff-02134842c4e5e921b3e0497b8942bf7eae460f3eaa5b3d67dd9f1d854e2a0445L17-R19): Changed the `max_age` value from `0` to `86400` to allow preflight responses to be cached for 24 hours.
* [`config/cors.php`](diffhunk://#diff-02134842c4e5e921b3e0497b8942bf7eae460f3eaa5b3d67dd9f1d854e2a0445L17-R19): Updated the `supports_credentials` setting from `true` to `false` to disable credential support in CORS requests.