### PR TITLE
Remove transformation options from upload settings in CloudinaryMediaUploadService to simplify media upload process.

### DIFF
--- a/app/Services/Cloudinary/CloudinaryMediaUploadService.php
+++ b/app/Services/Cloudinary/CloudinaryMediaUploadService.php
@@ -65,10 +65,6 @@ class CloudinaryMediaUploadService
                 'folder' => $folder,
                 'public_id' => $fileName,
                 'resource_type' => 'auto', // handles images, videos, pdf, etc.
-                'transformation' => [
-                    'quality' => 'auto:good', // bandwidth optimized
-                    'fetch_format' => 'auto'
-                ]
             ];
 
             $result = (new UploadApi())->upload($file->getRealPath(), $uploadOptions);


### PR DESCRIPTION
This pull request simplifies the `upload` method in the `CloudinaryMediaUploadService` by removing the `transformation` options from the `uploadOptions` array.

Optimization removal:

* [`app/Services/Cloudinary/CloudinaryMediaUploadService.php`](diffhunk://#diff-8eff62128fbb305316bb26878eb2a44e55b4b1f168cc7325bfb48108bb5f54c6L68-L71): Removed the `transformation` array, which included `quality` set to `'auto:good'` and `fetch_format` set to `'auto'`, from the `uploadOptions`. This change eliminates automatic bandwidth optimization and format fetching for uploaded media.