### PR TITLE
Update auditAction method in BookController to handle null audit values gracefully in success response.

### DIFF
--- a/app/Http/Controllers/Book/BookController.php
+++ b/app/Http/Controllers/Book/BookController.php
@@ -970,7 +970,7 @@ class BookController extends Controller
 
                 $book->refresh();
 
-                return $this->success(['audit' => $audit, 'book' => $book], 'Book declined.');
+                return $this->success(['audit' => $audit ?? null, 'book' => $book], 'Book declined.');
             }
 
             return $this->error('Invalid action.');


### PR DESCRIPTION
This pull request makes a small adjustment to the `auditAction` method in the `BookController` to ensure the `audit` key in the response is set to `null` if `$audit` is undefined.

* [`app/Http/Controllers/Book/BookController.php`](diffhunk://#diff-489363c05bb6ece0d2b1c38db727bc60810441a778eb9604e1c8f576d6792830L973-R973): Updated the `auditAction` method to include a null coalescing operator (`?? null`) for the `audit` key in the success response.