### PR TITLE
Implement book purchase check in reading access: ensure users must purchase a book before accessing its content.

### DIFF
--- a/app/Http/Controllers/Book/BookController.php
+++ b/app/Http/Controllers/Book/BookController.php
@@ -312,6 +312,14 @@ class BookController extends Controller
     {
         $user = $request->user();
 
+        // Check if user has purchased the book
+        if (!$user->purchasedBooks()->where('book_id', $bookId)->exists()) {
+            return $this->error(
+                'You must purchase the book before reading it.',
+                403
+            );
+        }
+
         $validator = Validator::make($request->all(), [
             // 'progress' => 'required|integer|min:0|max:100',
             'page' => 'required|string',

--- a/routes/api.php
+++ b/routes/api.php
@@ -132,7 +132,7 @@ Route::middleware([/* 'auth:api', */ 'auth:sanctum'])->group(function () {
     Route::get('books', [BookController::class, 'index']);
     Route::middleware(['role:admin,superadmin'])->get('books/all', [BookController::class, 'getAllBooks'])->name('get-all-books');
     Route::get('books/{id}', [BookController::class, 'show'])->name('book.show');
-    Route::get('books/{id}/download', [BookController::class, 'download'])->name('book.download');
+//    Route::get('books/{id}/download', [BookController::class, 'download'])->name('book.download');
     Route::post('books/preview', [BookController::class, 'extractPreview']);
     Route::put('books/{id}', [BookController::class, 'update']);
     Route::middleware(['role:admin,superadmin'])->post('books/{book}/delete', [BookController::class, 'destroy']);


### PR DESCRIPTION
This pull request introduces a new validation step in the `startReading` method to ensure users have purchased a book before accessing it and comments out the book download route in the API. Below are the most important changes:

### Validation Enhancements:
* Added a check in the `startReading` method of `BookController` to verify if the user has purchased the book before allowing them to start reading. If the check fails, an error response with a 403 status code is returned. (`app/Http/Controllers/Book/BookController.php`, [app/Http/Controllers/Book/BookController.phpR315-R322](diffhunk://#diff-489363c05bb6ece0d2b1c38db727bc60810441a778eb9604e1c8f576d6792830R315-R322))

### Route Modifications:
* Commented out the `books/{id}/download` route in `routes/api.php`, likely disabling the book download functionality for now. (`routes/api.php`, [routes/api.phpL135-R135](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL135-R135))