### PR TITLE
Remove MonitorAuth middleware from app.php middleware stack

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,9 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
         apiPrefix: 'api',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->append([CheckAppVersion::class,
-             MonitorAuth::class,
-        ]);
+        $middleware->append(CheckAppVersion::class);
 
         $middleware->alias([
             'monitor.auth' => MonitorAuth::class,


### PR DESCRIPTION
This pull request modifies the middleware configuration in the `bootstrap/app.php` file to streamline the middleware setup by removing unnecessary grouping.

Middleware configuration changes:

* [`bootstrap/app.php`](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518L21-R21): Removed the array grouping for middleware classes in the `append` method, leaving only `CheckAppVersion::class` directly appended.