### PR TITLE
Fix storage usage data retrieval in Admin API: update keys for accessing storage usage and media count from usage response.

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -527,8 +527,8 @@ Route::middleware(['monitor.auth'])->prefix('monitor')->group(function () {
             $usage = $api->usage();
 
             $details['cloud_name'] = config('services.cloud.cloud_name');
-            $details['storage_usage_bytes'] = $usage['usage']['total_storage_bytes'] ?? 'N/A';
-            $details['media_count'] = $usage['usage']['resources'] ?? 'N/A';
+            $details['storage_usage_bytes'] = $usage['storage']['usage'] ?? 'N/A';
+            $details['media_count'] = $usage['objects']['usage'] ?? 'N/A';
 
         } catch (ApiError $e) {
             $status = 'error';


### PR DESCRIPTION
This pull request updates the `routes/api.php` file to align with changes in the structure of the `$usage` data returned by the API. Specifically, it modifies how storage usage and media count are accessed.

### Key changes:
* Updated the keys used to retrieve `storage_usage_bytes` and `media_count` from `$usage` to reflect the new API structure (`storage.usage` and `objects.usage` respectively).