### PR TITLE
Add endpoint to get user's purchased books

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -40,7 +40,7 @@ class AuthController extends Controller
             $user = $userQuery->first();
             // dd('User Password', $user->password, Hash::check($request->password, $user->password));
             if (! $user || ! Hash::check($request->password, $user->password)) {
-                return $this->error('Invalid credentials', 401);
+                return $this->error('Invalid credentials', 400);
             }
 
             // throw new \RuntimeException('Test Exception'); // Uncomment to test exception handling

--- a/app/Http/Controllers/Book/BookController.php
+++ b/app/Http/Controllers/Book/BookController.php
@@ -1422,11 +1422,8 @@ class BookController extends Controller
             // $sortDir = strtolower($request->input('sort_dir', 'desc')) === 'asc' ? 'asc' : 'desc';
 
             $query = Book::query()
-                ->whereHas('purchasedBy', function ($q) use ($user) {
-                    $q->where('user_id', $user->id)
-                        ->whereHas('purchase', function ($pq) {
-                            $pq->where('status', 'completed');
-                        });
+                ->whereHas('purchasers', function ($q) use ($user) {
+                    $q->where('user_id', $user->id);
                 })
                 ->with([
                     'authors:id,name',

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -462,11 +462,10 @@ class UserController extends Controller
             $validator = Validator::make($request->all(), $rules);
 
             if ($validator->fails()) {
-                return $this->error(
-                    'Validation failed',
-                    400,
-                    $validator->errors()
-                );
+                return response()->json([
+                    'message' => 'Validation failed',
+                    'errors' => $validator->errors(),
+                ]);
             }
 
             // Handle profile picture upload if present

--- a/app/Http/Resources/User/UserResource.php
+++ b/app/Http/Resources/User/UserResource.php
@@ -53,6 +53,7 @@ class UserResource extends JsonResource
                 'last_name' => $this->last_name ?? '',
                 'mfa_secret' => $this->mfa_secret ?? '',
                 'name' => $this->name,
+                'username' => $this->username,
                 'preferences' => $this->preferences ?? [],
                 'bio' => $this->bio ?? '',
                 'profile_info' => $this->profile_info ?? [],
@@ -77,7 +78,7 @@ class UserResource extends JsonResource
             'last_login_at' => $this->last_login_at,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
-
+            'username' => $this->username,
             // Return only IDs instead of full book objects
             'purchased_books' => $this->whenLoaded('purchasedBooks', function () {
                 return $this->purchasedBooks->pluck('id')->toArray();

--- a/routes/api.php
+++ b/routes/api.php
@@ -150,6 +150,8 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::post('books', [BookController::class, 'store']);
     Route::middleware(['role:admin,superadmin'])->get('books/all', [BookController::class, 'getAllBooks'])->name('get-all-books');
     Route::get('books/search', [BookController::class, 'search']);
+    //get my purchased books
+    Route::get('books/my-purchases', [BookController::class, 'myPurchasedBooks']);
     Route::get('books/{id}', [BookController::class, 'show'])->name('book.show');
     Route::get('books/{id}/reviews', [BookController::class, 'getReviews']);
     Route::post('books/preview', [BookController::class, 'extractPreview']);
@@ -167,8 +169,6 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::middleware(['role:admin,superadmin'])->post('books/{action}/{bookId}', [BookController::class, 'auditAction'])
         ->where('action', '^(request_changes|approve|decline|restore)$');
     Route::delete('books/{id}/bookmark', [BookController::class, 'removeBookmark']);
-    //get my purchased books
-    Route::get('books/my-purchases', [BookController::class, 'myPurchasedBooks']);
 
     // Author-specific endpoints (only for account_type = 'author')
     Route::middleware(['role:author'])->prefix('author')->group(function () {


### PR DESCRIPTION
This pull request introduces several improvements and adjustments to user and book-related endpoints and resources. The main changes include refining the logic for retrieving a user's purchased books, updating the user resource to include the `username` field, modifying validation error responses for profile updates, and adjusting API routes for better organization.

**Book purchase logic and API routes:**

* Updated the query in `BookController::myPurchasedBooks` to use the `purchasers` relationship instead of filtering by `purchasedBy` and purchase status, simplifying the retrieval of a user's purchased books.
* Moved the `books/my-purchases` route to an earlier position in `routes/api.php` for clarity and removed a duplicate route definition. [[1]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR153-R154) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL170-L171)

**User resource and validation:**

* Added the `username` field to the output of `UserResource::toArray`, ensuring it is included in both the main user attributes and the additional data section. [[1]](diffhunk://#diff-c6e70928ef0c95d2a17e520c5894ad34d9e5486d218bcb98441fd899de9f7e83R56) [[2]](diffhunk://#diff-c6e70928ef0c95d2a17e520c5894ad34d9e5486d218bcb98441fd899de9f7e83L80-R81)
* Changed the validation error response in `UserController::updateProfile` to return a standard JSON structure with `message` and `errors` keys, improving consistency with typical API error responses.

**Other adjustments:**

* Changed the HTTP status code returned for invalid credentials in `AuthController::login` from 401 (Unauthorized) to 400 (Bad Request), aligning with the intended API response semantics.